### PR TITLE
Creates Policy Changes policy, on how we update our policies at Clef

### DIFF
--- a/Hiring Documents/Acknowledgement of Receipt of Changes.md
+++ b/Hiring Documents/Acknowledgement of Receipt of Changes.md
@@ -1,0 +1,27 @@
+# Acknowledgement of Receipt of Changes to the Employee Handbook
+
+I acknowledge I have received a copy of the changes to the Clef Employee Handbook that will take effect on **DATE**, have read them, and understand their provisions.  I further understand that if I have a question, I am obligated to ask one of the founders for clarification of any provisions in the Employee Handbook.
+
+I further understand that the statements contained in the handbook do not create any contractual or other legal obligations of employment.  I also understand that Clef may at any time modify, rescind, or revise any policy, benefit, or practice described in the handbook, except for its policy of at-will employment.
+
+I acknowledge that it is my responsibility to read and become familiar with the contents of the handbook.
+
+
+
+```
+
+Date: ________________________
+
+
+Print Name: ________________________
+
+
+Signature: ________________________
+
+```
+
+***
+
+
+## [Clef Employee Handbook **QTR YR**](https://getclef.com/handbook/QTR-YR)
+## [Changes this Quarter](https://getclef.com/handbook/changelog/QTR-YR)

--- a/Policy Changes.md
+++ b/Policy Changes.md
@@ -1,0 +1,63 @@
+# Policy Changes
+
+We want all of our policies to be living documents which can improve and change as we learn and grow as a company. This is how we'll propose and make changes to our policies.
+
+## Platforms and Tools
+
+We’re using several different tools and platforms to collect feedback and discuss the handbook. I’d like to codify the way we’re using them now, and then adapt as we find new ways to use them -- here’s how I see that now:
+
+### Github
+
+The handbook is hosted on Github, and anyone with a Github account can make an issue or open a pull request. This is an important home for the project, and we want to encourage and reward participation. We should respond to issues and comments here and use the edits in pull requests when they’re appropriate. B will do this regularly, and anyone else is free to respond when they're interested. This will help more people feel bought into the handbook and will help us gather more opinions on our policies.
+
+However, our internal processing does not need to happen on Github. Anyone should feel free to post their thoughts on Github, but there are a lot of sensitive topics that we’ll want to discuss internally. When we make changes, they should be merged on Github and we should explain our rationale there, but we don’t need to rehash the whole conversation.
+
+Github is a tool that the technical members of our team will already need to get familiar with, but special consideration should be taken to make sure our non-technical teammates have accounts and understand how to participate there.
+
+### Trello
+
+There is an internal Trello board at https://trello.com/b/gTmLFJgs that lists the current areas of interest, research, and proposals. This is where we can track the currently active internal discussions. If anyone has an issue they would like to start discussing, they can add a card to that board.
+
+### Google Docs
+Proposals should be written in Google Docs and linked to on the Trello board. There is a folder in “Active Projects” for ‘Handbook Research and Proposals’ which will hold the documents for research being done and proposals being written. This folder will be accessible to everyone internally, but will not be public.
+
+### Twitter
+
+A lot of folks have commented on the handbook outside of Github, especially on Twitter. The best thing for us to do is acknowledge their input and make sure it gets recorded in one of our other channels (especially Github) so that we don’t lose it. As individuals, anyone should feel free to talk about their opinions about feedback, but as Clef we should thank people for their input without being defensive.
+
+### Slack #handbook
+
+This channel is a good place for us to comment on policy changes asynchronously. Any questions, concerns, ideas, or discussion about our handbook can go here. If a conversation seems particularly interesting, we'll document it in Google docs or in a Github issue for future reference.
+
+## Continuing Work
+
+B will be blocking out a few hours every week on Friday mornings to look through and respond to issues, create proposals based on feedback, schedule time to talk about changes as a team, and merge in changes that are ready. Regular work will make sure that issues don’t stagnate, and any team member is welcome to create proposals or contribute to research on policies that they’re interested in.
+
+During our weekly team lunch, B will summarize open issues and proposals.
+
+## Proposals
+
+Any substantive change to the handbook should be laid out in a proposal that the team can comment on and discuss. Proposals should lay out the details of the change and the reasons for making them.
+
+## Discussion Meetings
+
+Every proposal should have an open meeting for feedback from the team. B will schedule these, and will be there for all of these discussions. Everyone is invited to all of these discussions, though attendance is not required. Participation in these conversations is really important because this is the best place for us to get a sense of how different team members relate to or will be impacted by a certain policy.
+
+Team members can also talk to their manager about concerns they have with a given change or policy privately, as well as ask that the manager bring up the issue if they’re not comfortable doing it themselves.
+
+Team members can comment on the proposal document before or after the meeting, in the meeting directly, or they can privately ask their manager or another employee to bring up their comments anonymously.
+
+There should always be notes from these meetings, which should live at the bottom of the proposal document.
+
+## Merging
+
+After changes have been proposed, discussed, and B decides they are ready to be merged into the handbook, B will do the merge on Github, update the card on Trello, post about it in Slack, and send an email.
+For major changes, he or another team member may also write a blog post about the change and the factors that went into making it. Blog posts should (with their permission) acknowledge all of the community members that participated in the discussion and helped us make the change.
+
+## Adoption
+
+Everyone at Clef needs to sign an [Acknowledgement of Receipt for the Employee Handbook](https://github.com/clef/handbook/blob/master/Hiring%20Documents/Acknowledgment%20of%20Receipt.md), but any change to these documents need to be acknowledged by every employee. Most companies do this on each employee's first day, and then have employees sign another acknowledgement whenever they make a change (because they're rare).
+
+Because we want these policies to constantly improve, we will merge changes as they appear. To make enforcing policy clear and unambiguous, we will adopt the changes at the beginning of each quarter. We will use milestones on Github to mark these canonical versions of the handbook, and we'll host them all at [getclef.com/handbook](https://getclef.com/handbook). They will be labeled with the dates that they applied, so if there is ever a question or complaint about a policy violation, it will be clear which policies applied on which dates at Clef.
+
+Every employee will need to sign an [Acknowledgement of Receipt of Changes to the Employee Handbook](https://github.com/clef/handbook/blob/master/Hiring%20Documents/Acknowledgment%20of%20Receipt%20of%20Changes.md) each quarter, which may not scale as we grow to more employees.


### PR DESCRIPTION
This new policy describes how we’ll make changes to the handbook in the
future and how we’ll adopt them. Also included in this commit is the
Acknowledgement of Changes document which employees will need to sign
each quarter.