### PR TITLE
Update link to CEO Twitter profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All feedback and suggestions (especially in the form of pull requests) are very 
 
 If these policies sound like a place where you want to work, check out our jobs postings at [getclef.com/about](https://getclef.com/about).
 
-— [B](https://twitter.com/brennenbyrne)
+— [B](https://twitter.com/iamb)
 
 CEO of Clef
 


### PR DESCRIPTION
https://twitter.com/brennenbyrne is empty and points to https://twitter.com/iamb as the correct one.